### PR TITLE
Ensure pipenv is installed before build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ before_install:
     - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
     # Manually initialize submodules
     - git submodule update --init --recursive
+    # Install pipenv
+    - pip install pipenv
 
 before_script:
   - ./script/setup


### PR DESCRIPTION
This PR updates the Travis config to ensure pipenv gets installed before the setup script is run.